### PR TITLE
Add a new kernel to eliminate calling to cudaDeviceSync

### DIFF
--- a/kuiper/source/op/kernels/cpu/scale_sum_kernel.cpp
+++ b/kuiper/source/op/kernels/cpu/scale_sum_kernel.cpp
@@ -1,0 +1,25 @@
+#include "scale_sum_kernel.h"
+#include <armadillo>
+#include "base/base.h"
+namespace kernel {
+void scale_sum_kernel_cpu(const tensor::Tensor& value, const tensor::Tensor& scale, 
+                          const tensor::Tensor& output, int pos, int size, int stride,
+                          void* stream) {
+  UNUSED(stream);
+  CHECK_EQ(value.is_empty(), false);
+  CHECK_EQ(scale.is_empty(), false);
+  CHECK_EQ(output.is_empty(), false);
+  CHECK_EQ(size, value.size());
+  CHECK_GE(size, scale.size());
+  CHECK_EQ(size, output.size());
+  arma::fvec value_vec(const_cast<float*>(value.ptr<float>()), value.size(), false, true);
+  arma::fvec scale_vec(const_cast<float*>(scale.ptr<float>()), scale.size(), false, true);
+  arma::fvec output_vec(const_cast<float*>(output.ptr<float>()), output.size(), false, true);
+
+  for (int i = 0; i <= pos; ++i) {
+    for (int j = 0; j < size; ++j) {
+      output_vec[j] += scale_vec[i] * value_vec[i * stride + j];
+    }
+  }
+}
+}  // namespace kernel

--- a/kuiper/source/op/kernels/cpu/scale_sum_kernel.h
+++ b/kuiper/source/op/kernels/cpu/scale_sum_kernel.h
@@ -1,0 +1,9 @@
+#ifndef SCALE_SUM_KERNEL_H
+#define SCALE_SUM_KERNEL_H
+#include <tensor/tensor.h>
+namespace kernel {
+void scale_sum_kernel_cpu(const tensor::Tensor& value, const tensor::Tensor& scale, 
+                          const tensor::Tensor& output, int t, int d, int stride,
+                          void* stream = nullptr);
+}
+#endif  // SCALE_KERNEL_H

--- a/kuiper/source/op/kernels/cuda/scale_sum_kernel.cu
+++ b/kuiper/source/op/kernels/cuda/scale_sum_kernel.cu
@@ -1,0 +1,37 @@
+#include "scale_sum_kernel.cuh"
+namespace kernel {
+__global__ void scale_sum_kernel_cu_fp32(const float* value, const float* scale, float* output, 
+                                         int pos, int size, int stride) {
+  int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (tid < size) {
+    float sum = 0.0f;
+      for (int i = 0; i <= pos; ++i) {
+        sum += value[i * stride + tid] * scale[i];
+      }
+    output[tid] = sum;
+  }
+}
+
+void scale_sum_kernel_cu(const tensor::Tensor& value, const tensor::Tensor& scale, 
+                         const tensor::Tensor& output, int pos, int size, int stride, void* stream) {
+  CHECK_EQ(value.is_empty(), false);
+  CHECK_EQ(scale.is_empty(), false);
+  CHECK_EQ(output.is_empty(), false);
+  CHECK_EQ(size, value.size());
+  CHECK_GE(size, scale.size());
+  CHECK_EQ(size, output.size());
+  int32_t thread_num = 512;
+  int32_t block_num = (size + thread_num - 1) / thread_num;
+  if (stream) {
+    cudaStream_t stream_ = static_cast<CUstream_st*>(stream);
+    scale_sum_kernel_cu_fp32<<<block_num, thread_num, 0, stream_>>>(
+      value.ptr<float>(), scale.ptr<float>(),
+      const_cast<float*>(output.ptr<float>()), pos, size, stride);
+  } else {
+    scale_sum_kernel_cu_fp32<<<block_num, thread_num>>>(
+      value.ptr<float>(), scale.ptr<float>(),
+      const_cast<float*>(output.ptr<float>()), pos, size, stride);
+  }
+}
+}  // namespace kernel

--- a/kuiper/source/op/kernels/cuda/scale_sum_kernel.cuh
+++ b/kuiper/source/op/kernels/cuda/scale_sum_kernel.cuh
@@ -1,0 +1,9 @@
+#ifndef SCALE_SUM_KERNEL_CU_H
+#define SCALE_SUM_KERNEL_CU_H
+#include <tensor/tensor.h>
+namespace kernel {
+void scale_sum_kernel_cu(const tensor::Tensor& value, const tensor::Tensor& scale, 
+                         const tensor::Tensor& output, int t, int d, int stride, 
+                         void* stream = nullptr);
+}
+#endif //SCALE_REDUCE_KERNEL_CU_H

--- a/kuiper/source/op/kernels/kernels_interface.h
+++ b/kuiper/source/op/kernels/kernels_interface.h
@@ -36,6 +36,11 @@ typedef void (*ScaleKernel)(float scale, const tensor::Tensor& input, void* stre
 
 typedef void (*SoftmaxInplaceKernel)(const tensor::Tensor& input, void* stream);
 
+typedef void (*ScaleSumKernel)(const tensor::Tensor& value, const tensor::Tensor& scale, 
+                               const tensor::Tensor& output, int t, int size, 
+                               int stride, void* stream);
+
+
 void softmax_inplace_cpu(const float* input_ptr, size_t size);
 
 AddKernel get_add_kernel(base::DeviceType device_type);
@@ -55,5 +60,7 @@ ScaleKernel get_scale_kernel(base::DeviceType device_type);
 SoftmaxInplaceKernel get_softmax_kernel(base::DeviceType device_type);
 
 SwigluKernel get_swiglu_kernel(base::DeviceType device_type, void* stream = nullptr);
+
+ScaleSumKernel get_scale_sum_kernel(base::DeviceType device_type);
 }  // namespace kernel
 #endif  // KERNELS_INTERFACE_H

--- a/kuiper/source/op/kernels/kernels_interfaces.cpp
+++ b/kuiper/source/op/kernels/kernels_interfaces.cpp
@@ -8,6 +8,7 @@
 #include "cpu/scale_kernel.h"
 #include "cpu/softmax_kernel.h"
 #include "cpu/swiglu_kernel.h"
+#include "cpu/scale_sum_kernel.h"
 #include "cuda/add_kernel.cuh"
 #include "cuda/matmul_kernel.cuh"
 #include "cuda/rmsnorm_kernel.cuh"
@@ -15,6 +16,7 @@
 #include "cuda/scale_kernel.cuh"
 #include "cuda/softmax_kernel.cuh"
 #include "cuda/swiglu_kernel.cuh"
+#include "cuda/scale_sum_kernel.cuh"
 #include "kernels_interface.h"
 namespace kernel {
 AddKernel get_add_kernel(base::DeviceType device_type) {
@@ -113,4 +115,16 @@ RMSNormKernel get_rmsnorm_kernel(base::DeviceType device_type) {
     return nullptr;
   }
 }
+
+ScaleSumKernel get_scale_sum_kernel(base::DeviceType device_type) {
+  if (device_type == base::DeviceType::kDeviceCPU) {
+    return scale_sum_kernel_cpu;
+  } else if (device_type == base::DeviceType::kDeviceCUDA) {
+    return scale_sum_kernel_cu;
+  } else {
+    LOG(FATAL) << "Unknown device type for get a scale and reduce kernel.";
+    return nullptr;
+  }
+}
+
 }  // namespace kernel


### PR DESCRIPTION
Actually, i think there is no need to call cudaDeviceSynchronize() in mha_kernel, so i merge the multiple callings to add kernel into one to improve the performance.