### PR TITLE
MHA复用、减少input和input_embedding空间

### DIFF
--- a/kuiper/include/op/mha.h
+++ b/kuiper/include/op/mha.h
@@ -12,6 +12,7 @@ class MultiHeadAttention : public op::Layer {
   base::Status check() const override;
 
   void set_pos(int32_t pos);
+  void set_layer_idx(int32_t layer_idx);
 
   base::Status base_forward() override;
 

--- a/kuiper/source/op/embedding.cpp
+++ b/kuiper/source/op/embedding.cpp
@@ -36,7 +36,7 @@ base::Status EmbeddingLayer::check() const {
     return status;
   }
 
-  status = check_tensor_with_dim(get_output(0), device_type_, data_type_, seq_len_, dim_);
+  status = check_tensor_with_dim(get_output(0), device_type_, data_type_, token_size, dim_);
   if (!status) {
     LOG(ERROR) << "The output tensor error in the embedding layer.";
     return status;

--- a/kuiper/source/op/mha.cpp
+++ b/kuiper/source/op/mha.cpp
@@ -38,6 +38,7 @@ base::Status MultiHeadAttention::base_forward() {
 }
 
 void MultiHeadAttention::set_pos(int32_t pos) { this->pos_ = pos; }
+void MultiHeadAttention::set_layer_idx(int32_t layer_idx) { this->layer_index_ = layer_idx; }
 
 base::Status MultiHeadAttention::check() const {
   base::Status status;


### PR DESCRIPTION
MHA可以只生成一个实例然后所有layer层复用，input和input_embedding在推理时的解码阶段都为1不需要申请seq_len这么大的空间，在prefill阶段input和input_embedding不够时会扩展为输入的tonken的大小这样在prefill阶段也可以减少空间使用