### PR TITLE
复用mha，减少input、input_embedding空间，避免重复初始化

### DIFF
--- a/kuiper/include/op/mha.h
+++ b/kuiper/include/op/mha.h
@@ -12,6 +12,7 @@ class MultiHeadAttention : public op::Layer {
   base::Status check() const override;
 
   void set_pos(int32_t pos);
+  void set_layer_idx(int32_t layer_idx);
 
   base::Status forward() override;
 

--- a/kuiper/source/model/llama2.cpp
+++ b/kuiper/source/model/llama2.cpp
@@ -37,6 +37,7 @@ void LLama2Layers::to_cuda(std::shared_ptr<kernel::CudaConfig> config) {
     if (mha_layer) {
       mha_layer->set_cuda_config(config);
       mha_layer->to_cuda();
+      break;
     }
   }
 
@@ -152,10 +153,11 @@ void LLama2Model::create_nonparam_layers() {
   llama_layers_->rope_layer_ = std::make_shared<op::RoPELayer>(
       device_type_, config_->dim_, config_->kv_dim_, config_->head_size_);
 
-  for (int32_t i = 0; i < config_->layer_num_; ++i) {
-    auto mha_layer = std::make_shared<op::MultiHeadAttention>(
-        device_type_, i, config_->kv_mul_, config_->kv_dim_, config_->seq_len_, config_->head_num_,
+  //mha复用
+  auto mha_layer = std::make_shared<op::MultiHeadAttention>(
+        device_type_, 0, config_->kv_mul_, config_->kv_dim_, config_->seq_len_, config_->head_num_,
         config_->head_size_);
+  for (int32_t i = 0; i < config_->layer_num_; ++i) {
     llama_layers_->mha_layers_.push_back(mha_layer);
   }
 
@@ -330,9 +332,10 @@ void LLama2Model::init_mem() {
   std::shared_ptr<base::DeviceAllocator> alloc_cu =
       base::CUDADeviceAllocatorFactory::get_instance();
   int32_t max_seq_len = config_->seq_len_;
-  tensor::Tensor input_tokens(base::DataType::kDataTypeInt32, static_cast<int32_t>(max_seq_len),
+  // 减少开销
+  tensor::Tensor input_tokens(base::DataType::kDataTypeInt32, static_cast<int32_t>(1),
                               true, alloc_cpu);
-  tensor::Tensor input_embeddings(base::DataType::kDataTypeFp32, max_seq_len, config_->dim_, true,
+  tensor::Tensor input_embeddings(base::DataType::kDataTypeFp32, 1, config_->dim_, true,
                                   alloc);
 
   CHECK(insert_buffer(ModelBufferType::kInputTokens, input_tokens));
@@ -488,7 +491,10 @@ base::Status LLama2Model::create_layers() {
 op::EmbeddingOutput LLama2Model::embedding(const std::vector<int>& tokens) const {
   auto input_tokens = get_buffer(ModelBufferType::kInputTokens);
   auto input_embeddings = get_buffer(ModelBufferType::kInputEmbeddings);
-  input_tokens.reshape({static_cast<int32_t>(tokens.size())});
+  if (input_tokens.size()!=tokens.size())
+  {  
+    input_tokens.reshape({static_cast<int32_t>(tokens.size())});
+    input_embeddings.reshape({static_cast<int32_t>(tokens.size()),config_->dim_});}
   for (int32_t i = 0; i < tokens.size(); ++i) {
     input_tokens.index<int32_t>(i) = tokens.at(i);
   }
@@ -582,6 +588,8 @@ void LLama2Model::attention_mha(int32_t layer_idx, const tensor::Tensor& pos_ten
   CHECK_NE(mha_layer, nullptr) << "The multi head attention layer is null pointer.";
   int pos = pos_tensor.index<int32_t>(0);
   std::dynamic_pointer_cast<op::MultiHeadAttention>(mha_layer)->set_pos(pos);
+  // 因为复用mha，手动设置layer_index_
+  std::dynamic_pointer_cast<op::MultiHeadAttention>(mha_layer)->set_layer_idx(layer_idx);
   STATUS_CHECK(mha_layer->forward(query, score_storage, key_cache, val_cache, mha_output));
 
   // wo @ attention output

--- a/kuiper/source/op/embedding.cpp
+++ b/kuiper/source/op/embedding.cpp
@@ -36,7 +36,7 @@ base::Status EmbeddingLayer::check() const {
     return status;
   }
 
-  status = check_tensor_with_dim(get_output(0), device_type_, data_type_, seq_len_, dim_);
+  status = check_tensor_with_dim(get_output(0), device_type_, data_type_, token_size, dim_);
   if (!status) {
     LOG(ERROR) << "The output tensor error in the embedding layer.";
     return status;

--- a/kuiper/source/op/kernels/cpu/mha_kernel.cpp
+++ b/kuiper/source/op/kernels/cpu/mha_kernel.cpp
@@ -8,30 +8,33 @@ void mha_kernel(int32_t pos, int32_t head_num, int32_t layer_index, int32_t seq_
                 const tensor::Tensor& key_cache_tensor, const tensor::Tensor& value_cache_tensor,
                 base::DeviceType device_type, CudaConfig* config) {
   int32_t layer_offset = layer_index * seq_len * kv_dim;
-  for (int32_t h = 0; h < head_num; ++h) {
-    float* score_head_addr = const_cast<float*>(score_tensor.ptr<float>() + h * seq_len);
-    float* query_head_addr = const_cast<float*>(query_tensor.ptr<float>() + h * head_size);
+  float scale = 1.f / std::sqrt(static_cast<float>(head_size));
 
-    std::shared_ptr<base::DeviceAllocator> allocator;
+  std::shared_ptr<base::DeviceAllocator> allocator;
     if (device_type == base::DeviceType::kDeviceCPU) {
       allocator = base::CPUDeviceAllocatorFactory::get_instance();
     } else {
       allocator = base::CUDADeviceAllocatorFactory::get_instance();
     }
+  for (int32_t h = 0; h < head_num; ++h) {
+    float* score_head_addr = const_cast<float*>(score_tensor.ptr<float>() + h * seq_len);
+    float* query_head_addr = const_cast<float*>(query_tensor.ptr<float>() + h * head_size);
 
+    
+    tensor::Tensor query_mat(base::DataType::kDataTypeFp32, head_size, false, nullptr,
+                               query_head_addr);
+    query_mat.set_device_type(device_type);
+    
     for (int32_t t = 0; t <= pos; t++) {
       int32_t cache_offset = t * kv_dim + (h / kv_mul) * head_size;
       const float* key_head_addr = key_cache_tensor.ptr<float>() + layer_offset + cache_offset;
       tensor::Tensor key_mat(base::DataType::kDataTypeFp32, 1, head_size, false, nullptr,
                              const_cast<float*>(key_head_addr));
-      tensor::Tensor query_mat(base::DataType::kDataTypeFp32, head_size, false, nullptr,
-                               query_head_addr);
+      
       tensor::Tensor score_mat(base::DataType::kDataTypeFp32, 1, false, nullptr,
                                score_head_addr + t);
       key_mat.set_device_type(device_type);
-      query_mat.set_device_type(device_type);
       score_mat.set_device_type(device_type);
-      float scale = 1.f / std::sqrt(static_cast<float>(head_size));
       get_matmul_kernel(device_type)(query_mat, key_mat, score_mat, scale, config);
     }
 

--- a/kuiper/source/op/mha.cpp
+++ b/kuiper/source/op/mha.cpp
@@ -38,7 +38,7 @@ base::Status MultiHeadAttention::forward() {
 }
 
 void MultiHeadAttention::set_pos(int32_t pos) { this->pos_ = pos; }
-
+void MultiHeadAttention::set_layer_idx(int32_t layer_idx) { this->layer_index_ = layer_idx; }
 base::Status MultiHeadAttention::check() const {
   base::Status status;
   const int32_t input_tensor_num = 4;


### PR DESCRIPTION
MHA可以只生成一个实例然后所有layer层复用，input和input_embedding在推理时的解码阶段都为1不需要申请seq_len这么大的空间，在prefill阶段input和input_embedding不够时会扩展为输入的tonken的大小这样在prefill阶段也可以减少空间使用。在mha_kernal.cpp中减少初始化scale和query_mat